### PR TITLE
Fix failing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.14"]
         runs-on: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ matrix.python-version }}
       - name: Install
         run: python -m pip install '.[all]' --group dev
       - name: Test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "numpy",
+    "numpy<2.4.0",
     "scipy>=1.10.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
@@ -44,7 +47,6 @@ dev = [
     "pytest>=8.3.5",
     "pytest-cov>=6.1.1",
     "scipy-stubs>=1.15.2.2",
-    "spikedata[all]",
 ]
 
 [tool.basedpyright]


### PR DESCRIPTION
I'm trying to fix the numpy version in CI without explicit version pinning. This commit shouldn't fix it, but I need a branch that runs CI.